### PR TITLE
mkch: Install squid

### DIFF
--- a/mkch/pkg.sls
+++ b/mkch/pkg.sls
@@ -7,4 +7,5 @@ mkch-packages-installed:
       - lvm2
       - netcat-openbsd
       - rsync
+      - squid
       - wget


### PR DESCRIPTION
In order to allow IPv6 provisioned admin nodes to reach IPv4 configured
hosts, we need a proxy server, add squid to the list of installed
packages.