### PR TITLE
Update automation via cron

### DIFF
--- a/mkch/cron.sls
+++ b/mkch/cron.sls
@@ -4,3 +4,14 @@
     - contents: |
         #!/bin/sh
         zypper -n up -l --no-recommends
+
+/etc/cron.hourly/update-automation:
+  file.managed:
+    - mode: 0755
+    - contents: |
+        #!/bin/sh
+        # managed by salt
+        path="/root/github.com/SUSE-Cloud/automation/scripts/jenkins"
+        if [ -x "$path/update_automation" ]; then
+            $path/update_automation
+        fi


### PR DESCRIPTION
The automation repos on mkch hosts can be updated by jenkins job, but
not all hosts are in the jenkins pool, meaning that hosts can
significantly lag behind HEAD of automation. Add a cron.hourly file to
keep them up to date.